### PR TITLE
Update DataColumn.php

### DIFF
--- a/src/DataColumn.php
+++ b/src/DataColumn.php
@@ -250,6 +250,8 @@ class DataColumn extends YiiDataColumn
      */
     protected function renderFilterCellContent()
     {
+        $content='';
+        if($this->filterType=="")
         $content = parent::renderFilterCellContent();
         $chkType = !empty($this->filterType) && $this->filterType !== GridView::FILTER_CHECKBOX &&
             $this->filterType !== GridView::FILTER_RADIO && !class_exists($this->filterType);


### PR DESCRIPTION
Kartik Select2 filter with multiple option not working, it was throwing error Array to string conversion. To make it work so we just added a condition here like parent::renderFilterCellContent(); will be called only if filterType is coming as blank in other cases it will call the parent function.
it resolve my problem

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-grid/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.